### PR TITLE
Add operating modes

### DIFF
--- a/codegen/src/main/java/com/zachary_moore/runner/Runner.java
+++ b/codegen/src/main/java/com/zachary_moore/runner/Runner.java
@@ -2,6 +2,7 @@ package com.zachary_moore.runner;
 
 import com.zachary_moore.SchemaProcessor;
 import com.zachary_moore.gen.Generator;
+import com.zachary_moore.gen.KTQLMode;
 import com.zachary_moore.spec.Schema;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
@@ -18,6 +19,10 @@ public class Runner {
         TypeDefinitionRegistry registry = new SchemaParser().parse(rawSchema);
         Schema schema = new SchemaProcessor(registry).process();
         Generator generator = new Generator(schema);
-        generator.generate(new File(outputPath), "com.zachary_moore");
+        generator.generate(
+                new File(outputPath),
+                "com.zachary_moore",
+                KTQLMode.INLINE_TRANSLATION
+        );
     }
 }

--- a/codegen/src/main/kotlin/com/zachary_moore/gen/Generator.kt
+++ b/codegen/src/main/kotlin/com/zachary_moore/gen/Generator.kt
@@ -12,13 +12,15 @@ class Generator(
 ) {
 
     fun generate(outputPath: File,
-                 apolloPackagePrefix: String) {
+                 apolloPackagePrefix: String,
+                 ktqlMode: KTQLMode) {
         val p = Properties()
         p.setProperty("file.resource.loader.path", "/Users/zsmoore/dev/KTQL/codegen/src/main/resources/")
         Velocity.init(p)
         val context = VelocityContext()
         context.put("schema", schema)
         context.put("apolloPrefix", apolloPackagePrefix)
+        context.put("KTQLMODE", ktqlMode.toString())
         val template = Velocity.getTemplate("KTQL.vm")
         val writer = StringWriter()
         template.merge(context, writer)

--- a/codegen/src/main/kotlin/com/zachary_moore/gen/KTQLMode.kt
+++ b/codegen/src/main/kotlin/com/zachary_moore/gen/KTQLMode.kt
@@ -1,0 +1,26 @@
+package com.zachary_moore.gen
+
+/**
+ * Generator Modes for KTQL
+ *
+ * INLINE_TRANSLATION - DSL will be stringified at runtime and a standard engine
+ *      will be used to make GraphQL calls.  Input data will be inlined.
+ *
+ * FILE_GENERATION - Using KSP, devs write functions which return KTQL.
+ *      From these KTQL objects we will generate GraphQL files for use in existing
+ *      systems such as apollo based applications
+ *
+ * CLIENT_BASED - DSL will be converted to graphql files for systems to use query id based systems.
+ *      Devs will use the KTQL object directly for making calls.  The generated client will send query id
+ *      + variables to server instead of raw queries
+ *
+ *
+ * Based on KTQLMode, the generated KTQL.kt class will have differing APIs with
+ * INLINE_TRANSLATION being the most straightforward, requiring variable aliases for
+ * any file based generation approach.
+ */
+enum class KTQLMode {
+    INLINE_TRANSLATION,
+    FILE_GENERATION,
+    CLIENT_BASED
+}

--- a/integration/src/main/resources/schema.graphqls
+++ b/integration/src/main/resources/schema.graphqls
@@ -48,7 +48,7 @@ type Query {
     Notifications(limit: Int): [Notification]
     NotificationsMeta: Meta
     SomeQuery(obj: Obj): Tweet
-    BatchTweet(id: [ID]!): Tweet
+    BatchTweet(ids: [ID]!): Tweet
 }
 
 input Obj {


### PR DESCRIPTION
From KDOC

```
/**
 * Generator Modes for KTQL
 *
 * INLINE_TRANSLATION - DSL will be stringified at runtime and a standard engine
 *      will be used to make GraphQL calls.  Input data will be inlined.
 *
 * FILE_GENERATION - Using KSP, devs write functions which return KTQL.
 *      From these KTQL objects we will generate GraphQL files for use in existing
 *      systems such as apollo based applications
 *
 * CLIENT_BASED - DSL will be converted to graphql files for systems to use query id based systems.
 *      Devs will use the KTQL object directly for making calls.  The generated client will send query id
 *      + variables to server instead of raw queries
 *
 *
 * Based on KTQLMode, the generated KTQL.kt class will have differing APIs with
 * INLINE_TRANSLATION being the most straightforward, requiring variable aliases for
 * any file based generation approach.
 */
 ```

Going to build inline first then file generation then client based